### PR TITLE
CONFIG-ART - Poner Campo Descripción Obligatorio 

### DIFF
--- a/src/app/modules/tm/components/articulo/create-update/articulo-create-update.html
+++ b/src/app/modules/tm/components/articulo/create-update/articulo-create-update.html
@@ -39,6 +39,7 @@
                         name="descripcion" 
                         formControlName="descripcion"
                         label="Descripción"
+                        [required]="true"
                         placeholder="Ingrese una breve descripción">
                     </plex-text>
                 </div>


### PR DESCRIPTION
- Se cambia el campo Descripción a obligatorio.
- Esto para el correcto funcionamiento al crear un nuevo artículo.